### PR TITLE
Enable utf8 encoding

### DIFF
--- a/src/com/hms_networks/americas/sc/mqtt/package.html
+++ b/src/com/hms_networks/americas/sc/mqtt/package.html
@@ -2,7 +2,7 @@
 <BODY>
 Ewon Flexy MQTT library created by the HMS Networks MU Americas Solution Center.
 
-@version 1.1
+@version 1.2
 @author HMS Networks, MU Americas Solution Center
 </BODY>
 </HTML>


### PR DESCRIPTION
 - Additional constructor with boolean parameter enable utf8 parameter.
 - Additional method to publish MQTT message w/ config utf8.
 - Increase version to 1.2.